### PR TITLE
Support Chef12

### DIFF
--- a/lib/minitest-chef-handler/resources.rb
+++ b/lib/minitest-chef-handler/resources.rb
@@ -20,7 +20,7 @@ module MiniTest
           if Gem::Version.new(::Chef::VERSION) < Gem::Version.new("10.14.0")
             provider = ::Chef::Platform.provider_for_resource(res)
           else
-            provider = ::Chef::Platform.provider_for_resource(res, :create)
+            provider = res.provider_for_action(:create)
           end
 
           provider.load_current_resource


### PR DESCRIPTION
Refer to https://github.com/opscode/chef/issues/2558 for some additional backstory here, but the gist of it that starting in Chef 12, trying to make assertions against the some resources will toss a `Cannot find a provider for blah` message.

This change should be a backward compatible change that avoids that error on Chef 12. I ran the change through a converge and test cycle on Chef 12.0.0, 11.16.4, 10.26.0 and 10.14.0.